### PR TITLE
2017 Day 3: Spiral Memory

### DIFF
--- a/go/adventofcode/y17d03.go
+++ b/go/adventofcode/y17d03.go
@@ -1,46 +1,55 @@
 package adventofcode
 
-import (
-	"image"
-	"log"
-)
+import "math"
 
-func y17d03(input string, part int) (dist int) {
+func y17d03(input string, part int) (answer int) {
 	if part == 1 {
-		dist = y17d03Solve1(strToInt(input))
+		answer = y17d03Solve1(strToInt(input))
+	} else {
+		answer = y17d03Solve2(strToInt(input))
 	}
 	return
 }
 
-func y17d03Solve1(iNumber int) int {
-	log.Println("iNumber", iNumber)
-	dirs := []image.Point{image.Point{X: 0, Y: 1}, image.Point{X: -1, Y: 0}, image.Point{X: 0, Y: -1}, image.Point{X: 1, Y: 0}} // R, U, L, D
-	d, r, c, n := 0, 0, 0, 2
-	getToSquaredNum := map[image.Point]int{image.Point{0, 0}: 1, image.Point{0, 1}: 2}
-	for len(getToSquaredNum) < iNumber {
-		dl := dirs[(d+1)%4]
-		cl := image.Point{Y: r + dl.Y, X: c + dl.X}
-		if _, exists := getToSquaredNum[cl]; !exists {
-			d = (d + 1) % 4
+func y17d03Solve2(target int) int {
+	dirs := [4][2]int{{0, 1}, {-1, 0}, {0, -1}, {1, 0}}
+	nd := [][2]int{{-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}}
+	posSum := map[[2]int]int{{0, 0}: 1, {0, 1}: 1}
+	facing := 0
+	row, col := 0, 1
+	for len(posSum) < target {
+		ld := dirs[(facing+1)%4]
+		left := [2]int{row + ld[0], col + ld[1]}
+		if _, ok := posSum[left]; !ok {
+			facing = (facing + 1) % 4
 		}
-		dp := dirs[d]
-		r += dp.Y
-		c += dp.X
-		np := image.Point{Y: r, X: c}
-		getToSquaredNum[np] = n
-		n++
+		diff := dirs[facing]
+		row += diff[0]
+		col += diff[1]
+		next := [2]int{row, col}
+		sum := 0
+		for _, d := range nd {
+			sum += posSum[[2]int{row + d[0], col + d[1]}]
+		}
+		if sum > target {
+			return sum
+		}
+		posSum[next] = sum
 	}
-	return y17d03Manhattan(0, 0, r, c)
+	return -1
 }
 
-func y17d03Manhattan(x1, y1, x2, y2 int) int {
-	dx := x1 - x2
-	dy := y1 - y2
-	if dx < 0 {
-		dx *= -1
+func y17d03Solve1(target int) int {
+	n, l := 0, 0
+	n = int(math.Ceil(math.Sqrt(float64(target))))
+	if n%2 == 0 {
+		l = n + 1
+	} else {
+		l = n
 	}
-	if dy < 0 {
-		dy *= -1
-	}
-	return dx + dy
+	min := l*l - l + 1
+	max := l * l
+	mid := min + (max-min)/2
+	drift := int(math.Abs(float64(target - mid)))
+	return l/2 + drift
 }

--- a/go/adventofcode/y17d03_test.go
+++ b/go/adventofcode/y17d03_test.go
@@ -2,7 +2,7 @@ package adventofcode
 
 import "testing"
 
-func xxxTest_y17d03(t *testing.T) {
+func Test_y17d03(t *testing.T) {
 	type args struct {
 		input string
 		part  int
@@ -12,10 +12,8 @@ func xxxTest_y17d03(t *testing.T) {
 		args args
 		want int
 	}{
-		{"test square 1", args{input: "1", part: 1}, 0},
-		{"test square 12", args{input: "12", part: 1}, 3},
-		{"test square 23", args{input: "23", part: 1}, 2},
-		{"test square 1024", args{input: "1024", part: 1}, 31},
+		{"test 1", args{input: "325489", part: 1}, 552},
+		{"test 2", args{input: "325489", part: 2}, 330785},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Execution

```
> make run YEAR=2017 DAY=3
Year=2017 Day=03 Part 1: 552 (23.166µs)
Year=2017 Day=03 Part 2: 330785 (43.667µs)
```

# Tests

```
> make test | grep y17d03.go | column -t
github.com/bandarji/aoc/adventofcode/y17d03.go:5:   y17d03        100.0%
github.com/bandarji/aoc/adventofcode/y17d03.go:14:  y17d03Solve2  95.2%
github.com/bandarji/aoc/adventofcode/y17d03.go:42:  y17d03Solve1  90.0%
```
