### PR TITLE
2017 Day 6: Memory Reallocation

### DIFF
--- a/go/adventofcode/base2017.go
+++ b/go/adventofcode/base2017.go
@@ -14,8 +14,8 @@ func NewAOCDay2017(day int) (DayRunner, error) {
 		return &Y17D04{}, nil
 	case 5:
 		return &Y17D05{}, nil
-	// case 6:
-	// 	return &Y17D06{}, nil
+	case 6:
+		return &Y17D06{}, nil
 	// case 7:
 	// 	return &Y17D07{}, nil
 	// case 8:

--- a/go/adventofcode/interfaces2017.go
+++ b/go/adventofcode/interfaces2017.go
@@ -85,21 +85,21 @@ func (d *Y17D05) Part2(year, day int) string {
 	return fmt.Sprintf("Year=%d Day=%02d Part 2: %d (%v)", year, day, y17d05(d.GetInput(year, day), 2), time.Since(start))
 }
 
-// type Y17D06 struct{}
+type Y17D06 struct{}
 
-// func (d *Y17D06) GetInput(year, day int) string {
-// 	return readContent(formatFilename(year, day))
-// }
+func (d *Y17D06) GetInput(year, day int) string {
+	return readContent(formatFilename(year, day))
+}
 
-// func (d *Y17D06) Part1(year, day int) string {
-// 	start := time.Now()
-// 	return fmt.Sprintf("Year=%d Day=%02d Part 1: %s (%v)", year, day, Y17d06(d.GetInput(year, day), 1), time.Since(start))
-// }
+func (d *Y17D06) Part1(year, day int) string {
+	start := time.Now()
+	return fmt.Sprintf("Year=%d Day=%02d Part 1: %d (%v)", year, day, y17d06(d.GetInput(year, day), 1), time.Since(start))
+}
 
-// func (d *Y17D06) Part2(year, day int) string {
-// 	start := time.Now()
-// 	return fmt.Sprintf("Year=%d Day=%02d Part 2: %s (%v)", year, day, Y17d06(d.GetInput(year, day), 2), time.Since(start))
-// }
+func (d *Y17D06) Part2(year, day int) string {
+	start := time.Now()
+	return fmt.Sprintf("Year=%d Day=%02d Part 2: %d (%v)", year, day, y17d06(d.GetInput(year, day), 2), time.Since(start))
+}
 
 // type Y17D07 struct{}
 

--- a/go/adventofcode/y17d06.go
+++ b/go/adventofcode/y17d06.go
@@ -1,0 +1,75 @@
+package adventofcode
+
+import (
+	"fmt"
+	"strings"
+)
+
+type y17d06State struct {
+	memSize, bigBankIndex, bigBankValue int
+	banks                               []int
+}
+
+func (s *y17d06State) findLargestBank() {
+	hi := s.banks[0]
+	for i := 0; i < s.memSize; i++ {
+		if s.banks[i] > hi {
+			hi = s.banks[i]
+		}
+	}
+	for i := 0; i < s.memSize; i++ {
+		if s.banks[i] == hi {
+			s.bigBankIndex = i
+			s.bigBankValue = hi
+			break
+		}
+	}
+}
+
+func (s y17d06State) hash() string {
+	hash := strings.Builder{}
+	for _, bank := range s.banks {
+		hash.WriteString(fmt.Sprintf("%d,", bank))
+	}
+	return hash.String()
+}
+
+func (s *y17d06State) reallocate() {
+	s.findLargestBank()
+	s.banks[s.bigBankIndex] = 0
+	for i := (s.bigBankIndex + 1) % s.memSize; s.bigBankValue > 0; i = (i + 1) % s.memSize {
+		s.banks[i]++
+		s.bigBankValue--
+	}
+}
+
+func y17d06(input string, part int) int {
+	state := y17d06ParseInput(input)
+	seen := map[string]int{}
+	i := 0
+	for {
+		if seen[state.hash()] != 0 {
+			if part == 1 {
+				return i
+			} else {
+				return i - seen[state.hash()]
+			}
+		}
+		seen[state.hash()] = i
+		state.reallocate()
+		i++
+	}
+}
+
+func y17d06ParseInput(input string) *y17d06State {
+	state := &y17d06State{
+		memSize: 0,
+		banks:   []int{},
+	}
+	for n := range strings.FieldsSeq(input) {
+		state.banks = append(state.banks, strToInt(n))
+		state.memSize++
+	}
+	state.memSize = len(state.banks)
+	return state
+}

--- a/go/adventofcode/y17d06_test.go
+++ b/go/adventofcode/y17d06_test.go
@@ -1,0 +1,27 @@
+package adventofcode
+
+import "testing"
+
+const y17d06TestInput string = `0 2 7 0`
+
+func Test_y17d06(t *testing.T) {
+	type args struct {
+		input string
+		part  int
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantCycles int
+	}{
+		{"test 1", args{input: y17d06TestInput, part: 1}, 5},
+		{"test 2", args{input: y17d06TestInput, part: 2}, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotCycles := y17d06(tt.args.input, tt.args.part); gotCycles != tt.wantCycles {
+				t.Errorf("y17d06() = %v, want %v", gotCycles, tt.wantCycles)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Execution

```
> make run YEAR=2017 DAY=6
Year=2017 Day=06 Part 1: 14029 (47.411542ms)
Year=2017 Day=06 Part 2: 2765 (31.046833ms)
```

# Tests

```
> make test | grep y17d06.go | column -t
github.com/bandarji/aoc/adventofcode/y17d06.go:13:  findLargestBank   100.0%
github.com/bandarji/aoc/adventofcode/y17d06.go:29:  hash              100.0%
github.com/bandarji/aoc/adventofcode/y17d06.go:37:  reallocate        100.0%
github.com/bandarji/aoc/adventofcode/y17d06.go:46:  y17d06            100.0%
github.com/bandarji/aoc/adventofcode/y17d06.go:64:  y17d06ParseInput  100.0%
```
