### PR TITLE
2017 Day 7: Recursive Circus (Part One)

### DIFF
--- a/go/adventofcode/base2017.go
+++ b/go/adventofcode/base2017.go
@@ -16,8 +16,8 @@ func NewAOCDay2017(day int) (DayRunner, error) {
 		return &Y17D05{}, nil
 	case 6:
 		return &Y17D06{}, nil
-	// case 7:
-	// 	return &Y17D07{}, nil
+	case 7:
+		return &Y17D07{}, nil
 	// case 8:
 	// 	return &Y17D08{}, nil
 	// case 9:

--- a/go/adventofcode/interfaces2017.go
+++ b/go/adventofcode/interfaces2017.go
@@ -101,21 +101,21 @@ func (d *Y17D06) Part2(year, day int) string {
 	return fmt.Sprintf("Year=%d Day=%02d Part 2: %d (%v)", year, day, y17d06(d.GetInput(year, day), 2), time.Since(start))
 }
 
-// type Y17D07 struct{}
+type Y17D07 struct{}
 
-// func (d *Y17D07) GetInput(year, day int) string {
-// 	return readContent(formatFilename(year, day))
-// }
+func (d *Y17D07) GetInput(year, day int) string {
+	return readContent(formatFilename(year, day))
+}
 
-// func (d *Y17D07) Part1(year, day int) string {
-// 	start := time.Now()
-// 	return fmt.Sprintf("Year=%d Day=%02d Part 1: %d (%v)", year, day, Y17d07(d.GetInput(year, day), 1), time.Since(start))
-// }
+func (d *Y17D07) Part1(year, day int) string {
+	start := time.Now()
+	return fmt.Sprintf("Year=%d Day=%02d Part 1: %s (%v)", year, day, y17d07(d.GetInput(year, day), 1), time.Since(start))
+}
 
-// func (d *Y17D07) Part2(year, day int) string {
-// 	start := time.Now()
-// 	return fmt.Sprintf("Year=%d Day=%02d Part 2: %d (%v)", year, day, Y17d07(d.GetInput(year, day), 2), time.Since(start))
-// }
+func (d *Y17D07) Part2(year, day int) string {
+	start := time.Now()
+	return fmt.Sprintf("Year=%d Day=%02d Part 2: %s (%v)", year, day, y17d07(d.GetInput(year, day), 2), time.Since(start))
+}
 
 // type Y17D08 struct{}
 

--- a/go/adventofcode/y17d07.go
+++ b/go/adventofcode/y17d07.go
@@ -1,0 +1,61 @@
+package adventofcode
+
+import (
+	"strings"
+)
+
+type y17d07Node struct {
+	weight int
+	edges  []string
+}
+
+func y17d07(input string, part int) (name string) {
+	graph := y17d07ParseInput(input)
+	names := y17d07MapNames(graph)
+	if part == 1 {
+		name = y17d07Part1(graph, names)
+	} else {
+		name = ""
+	}
+	return
+}
+
+func y17d07Part1(graph map[string]y17d07Node, names map[string]bool) string {
+	for _, node := range graph {
+		for _, name := range node.edges {
+			delete(names, name)
+		}
+	}
+	// log.Println(names)
+	for k := range names {
+		return k
+	}
+	return ""
+}
+
+func y17d07ParseInput(input string) map[string]y17d07Node {
+	graph := map[string]y17d07Node{}
+	for line := range strings.SplitSeq(input, "\n") {
+		left, right, found := strings.Cut(line, " -> ")
+		fields := strings.Fields(left)
+		name := fields[0]
+		weight := strToInt(strings.Trim(fields[1], "()"))
+		edges := []string{}
+		if found {
+			edges = strings.Split(right, ", ")
+		}
+		graph[name] = y17d07Node{
+			weight: weight,
+			edges:  edges,
+		}
+	}
+	return graph
+}
+
+func y17d07MapNames(graph map[string]y17d07Node) map[string]bool {
+	names := map[string]bool{}
+	for name := range graph {
+		names[name] = true
+	}
+	return names
+}

--- a/go/adventofcode/y17d07_test.go
+++ b/go/adventofcode/y17d07_test.go
@@ -1,0 +1,38 @@
+package adventofcode
+
+import "testing"
+
+const y17d07TestInput string = `pbga (66)
+xhth (57)
+ebii (61)
+havc (66)
+ktlj (57)
+fwft (72) -> ktlj, cntj, xhth
+qoyq (66)
+padx (45) -> pbga, havc, qoyq
+tknk (41) -> ugml, padx, fwft
+jptl (61)
+ugml (68) -> gyxo, ebii, jptl
+gyxo (61)
+cntj (57)`
+
+func Test_y17d07(t *testing.T) {
+	type args struct {
+		input string
+		part  int
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantName string
+	}{
+		{"test part 1", args{y17d07TestInput, 1}, "tknk"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotName := y17d07(tt.args.input, tt.args.part); gotName != tt.wantName {
+				t.Errorf("y17d07() = %v, want %v", gotName, tt.wantName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Execution

```
> make run YEAR=2017 DAY=07
Year=2017 Day=07 Part 1: rqwgj (410.667µs)
Year=2017 Day=07 Part 2:  (332.417µs)
```

# Tests

```
> make test | grep y17d07.go | column -t
github.com/bandarji/aoc/adventofcode/y17d07.go:12:  y17d07            83.3%
github.com/bandarji/aoc/adventofcode/y17d07.go:23:  y17d07Part1       83.3%
github.com/bandarji/aoc/adventofcode/y17d07.go:36:  y17d07ParseInput  100.0%
github.com/bandarji/aoc/adventofcode/y17d07.go:55:  y17d07MapNames    100.0%
```
