### PR TITLE
2017 Day 9: Stream Processing

### DIFF
--- a/go/adventofcode/base2017.go
+++ b/go/adventofcode/base2017.go
@@ -20,8 +20,8 @@ func NewAOCDay2017(day int) (DayRunner, error) {
 		return &Y17D07{}, nil
 	case 8:
 		return &Y17D08{}, nil
-	// case 9:
-	// 	return &Y17D09{}, nil
+	case 9:
+		return &Y17D09{}, nil
 	// case 10:
 	// 	return &Y17D10{}, nil
 	// case 11:

--- a/go/adventofcode/interfaces2017.go
+++ b/go/adventofcode/interfaces2017.go
@@ -133,21 +133,21 @@ func (d *Y17D08) Part2(year, day int) string {
 	return fmt.Sprintf("Year=%d Day=%02d Part 2: %d (%v)", year, day, y17d08(d.GetInput(year, day), 2), time.Since(start))
 }
 
-// type Y17D09 struct{}
+type Y17D09 struct{}
 
-// func (d *Y17D09) GetInput(year, day int) string {
-// 	return readContent(formatFilename(year, day))
-// }
+func (d *Y17D09) GetInput(year, day int) string {
+	return readContent(formatFilename(year, day))
+}
 
-// func (d *Y17D09) Part1(year, day int) string {
-// 	start := time.Now()
-// 	return fmt.Sprintf("Year=%d Day=%02d Part 1: %d (%v)", year, day, Y17d09(d.GetInput(year, day), 1), time.Since(start))
-// }
+func (d *Y17D09) Part1(year, day int) string {
+	start := time.Now()
+	return fmt.Sprintf("Year=%d Day=%02d Part 1: %d (%v)", year, day, y17d09(d.GetInput(year, day), 1), time.Since(start))
+}
 
-// func (d *Y17D09) Part2(year, day int) string {
-// 	start := time.Now()
-// 	return fmt.Sprintf("Year=%d Day=%02d Part 2: %d (%v)", year, day, Y17d09(d.GetInput(year, day), 2), time.Since(start))
-// }
+func (d *Y17D09) Part2(year, day int) string {
+	start := time.Now()
+	return fmt.Sprintf("Year=%d Day=%02d Part 2: %d (%v)", year, day, y17d09(d.GetInput(year, day), 2), time.Since(start))
+}
 
 // type Y17D10 struct{}
 

--- a/go/adventofcode/y17d09.go
+++ b/go/adventofcode/y17d09.go
@@ -1,0 +1,34 @@
+package adventofcode
+
+func y17d09(input string, part int) int {
+	score, openers, garChars := 0, 0, 0
+	garbaged := false
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		switch garbaged {
+		case true:
+			switch ch {
+			case '!':
+				i++
+			case '>':
+				garbaged = false
+			default:
+				garChars++
+			}
+		case false:
+			switch ch {
+			case '{':
+				openers++
+			case '<':
+				garbaged = true
+			case '}':
+				score += openers
+				openers--
+			}
+		}
+	}
+	if part == 1 {
+		return score
+	}
+	return garChars
+}

--- a/go/adventofcode/y17d09_test.go
+++ b/go/adventofcode/y17d09_test.go
@@ -1,0 +1,37 @@
+package adventofcode
+
+import "testing"
+
+func Test_y17d09(t *testing.T) {
+	type args struct {
+		input string
+		part  int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{"y17d09p1 '{}'", args{input: "{}", part: 1}, 1},
+		{"y17d09p1 '{{{}}}", args{input: "{{{}}}", part: 1}, 6},
+		{"y17d09p1 '{{},{}}", args{input: "{{},{}}", part: 1}, 5},
+		{"y17d09p1 '{{{},{},{{}}}}", args{input: "{{{},{},{{}}}}", part: 1}, 16},
+		{"y17d09p1 '{<a>,<a>,<a>,<a>}", args{input: "{<a>,<a>,<a>,<a>}", part: 1}, 1},
+		{"y17d09p1 '{{<ab>},{<ab>},{<ab>},{<ab>}}", args{input: "{{<ab>},{<ab>},{<ab>},{<ab>}}", part: 1}, 9},
+		{"y17d09p1 '{{<!!>},{<!!>},{<!!>},{<!!>}}", args{input: "{{<!!>},{<!!>},{<!!>},{<!!>}}", part: 1}, 9},
+		{"y17d09p1 '{{<a!>},{<a!>},{<a!>},{<ab>}}", args{input: "{{<a!>},{<a!>},{<a!>},{<ab>}}", part: 1}, 3},
+		{"y17d09p1 '<>'", args{input: "<>", part: 2}, 0},
+		{"y17d09p1 '<random characters>'", args{input: "<random characters>", part: 2}, 17},
+		{"y17d09p1 '<<<<>'", args{input: "<<<<>", part: 2}, 3},
+		{"y17d09p1 '<{!>}>'", args{input: "<{!>}>", part: 2}, 2},
+		{"y17d09p1 '<!!>'", args{input: "<!!>", part: 2}, 0},
+		{"y17d09p1 '<!!!>>'", args{input: "<!!!>>", part: 2}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := y17d09(tt.args.input, tt.args.part); got != tt.want {
+				t.Errorf("y17d09() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Execution

```
> make run YEAR=2017 DAY=9
Year=2017 Day=09 Part 1: 11347 (290.083µs)
Year=2017 Day=09 Part 2: 5404 (190µs)
```

# Tests

```
> make test | grep y17d09.go | column -t
github.com/bandarji/aoc/adventofcode/y17d09.go:3:  y17d09  100.0%
```
