### PR TITLE
2017 Day 7: Recursive Circus

### DIFF
--- a/go/adventofcode/y17d07.go
+++ b/go/adventofcode/y17d07.go
@@ -1,6 +1,7 @@
 package adventofcode
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -9,15 +10,14 @@ type y17d07Node struct {
 	edges  []string
 }
 
-func y17d07(input string, part int) (name string) {
+func y17d07(input string, part int) string {
 	graph := y17d07ParseInput(input)
 	names := y17d07MapNames(graph)
+	part1 := y17d07Part1(graph, names)
 	if part == 1 {
-		name = y17d07Part1(graph, names)
-	} else {
-		name = ""
+		return part1
 	}
-	return
+	return y17d07Part2(graph, part1)
 }
 
 func y17d07Part1(graph map[string]y17d07Node, names map[string]bool) string {
@@ -31,6 +31,47 @@ func y17d07Part1(graph map[string]y17d07Node, names map[string]bool) string {
 		return k
 	}
 	return ""
+}
+
+func y17d07CalcWeights(graph map[string]y17d07Node) func(string) int {
+	var insFunc func(string) int
+	insFunc = func(root string) int {
+		sum := graph[root].weight
+		for _, dependent := range graph[root].edges {
+			sum += insFunc(dependent)
+		}
+		return sum
+	}
+	return insFunc
+}
+
+func y17d07Part2(graph map[string]y17d07Node, current string) string {
+	weightsFunc := y17d07CalcWeights(graph)
+	neighbors := []string{}
+	for i := 0; i < len(graph); i++ {
+		downstreamWeights := map[int][]string{}
+		for _, dependent := range graph[current].edges {
+			weight := weightsFunc(dependent)
+			downstreamWeights[weight] = append(downstreamWeights[weight], dependent)
+		}
+		if len(downstreamWeights) > 1 {
+			neighbors = graph[current].edges
+			for _, names := range downstreamWeights {
+				if len(names) == 1 {
+					current = names[0]
+				}
+			}
+		} else if len(downstreamWeights) == 1 {
+			currentWeight := weightsFunc(current)
+			for _, neighb := range neighbors {
+				if neighb != current {
+					wanted := weightsFunc(neighb)
+					return fmt.Sprintf("%d", graph[current].weight-(currentWeight-wanted))
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", -1)
 }
 
 func y17d07ParseInput(input string) map[string]y17d07Node {

--- a/go/adventofcode/y17d07_test.go
+++ b/go/adventofcode/y17d07_test.go
@@ -27,6 +27,7 @@ func Test_y17d07(t *testing.T) {
 		wantName string
 	}{
 		{"test part 1", args{y17d07TestInput, 1}, "tknk"},
+		{"test part 2", args{y17d07TestInput, 2}, "60"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Execution

```
> make run YEAR=2017 DAY=7
Year=2017 Day=07 Part 1: rqwgj (406.458µs)
Year=2017 Day=07 Part 2: 333 (388.792µs)
```

# Tests

```
> make test | grep y17d07.go | column -t
github.com/bandarji/aoc/adventofcode/y17d07.go:13:  y17d07             100.0%
github.com/bandarji/aoc/adventofcode/y17d07.go:23:  y17d07Part1        83.3%
github.com/bandarji/aoc/adventofcode/y17d07.go:36:  y17d07CalcWeights  100.0%
github.com/bandarji/aoc/adventofcode/y17d07.go:48:  y17d07Part2        94.7%
github.com/bandarji/aoc/adventofcode/y17d07.go:77:  y17d07ParseInput   100.0%
github.com/bandarji/aoc/adventofcode/y17d07.go:96:  y17d07MapNames     100.0%
```
