### PR TITLE
2017 Day 10: Knot Hash

### DIFF
--- a/go/adventofcode/interfaces2017.go
+++ b/go/adventofcode/interfaces2017.go
@@ -157,12 +157,12 @@ func (d *Y17D10) GetInput(year, day int) string {
 
 func (d *Y17D10) Part1(year, day int) string {
 	start := time.Now()
-	return fmt.Sprintf("Year=%d Day=%02d Part 1: %d (%v)", year, day, y17d10(d.GetInput(year, day), 256, 1), time.Since(start))
+	return fmt.Sprintf("Year=%d Day=%02d Part 1: %s (%v)", year, day, y17d10(d.GetInput(year, day), 256, 1), time.Since(start))
 }
 
 func (d *Y17D10) Part2(year, day int) string {
 	start := time.Now()
-	return fmt.Sprintf("Year=%d Day=%02d Part 2: %d (%v)", year, day, y17d10(d.GetInput(year, day), 256, 2), time.Since(start))
+	return fmt.Sprintf("Year=%d Day=%02d Part 2: %s (%v)", year, day, y17d10(d.GetInput(year, day), 256, 2), time.Since(start))
 }
 
 // type Y17D11 struct{}

--- a/go/adventofcode/y17d10.go
+++ b/go/adventofcode/y17d10.go
@@ -1,26 +1,39 @@
 package adventofcode
 
 import (
+	"fmt"
 	"strings"
 )
 
-func y17d10Modulo(number int, length int) int {
-	if number < 0 {
-		return y17d10Modulo(length+number, length)
-	} else {
-		return number % length
+func y17d10(input string, listLength, part int) string {
+	sb := strings.Builder{}
+	lengths := y17d10ParseInput(input)
+	if part == 2 {
+		lengths = y17d10ParseInputPart2(input)
 	}
+	list := y17d10CreateList(listLength)
+	if part == 1 {
+		y17d10KnotHash(list, lengths, 1)
+		sb.WriteString(fmt.Sprintf("%d", list[0]*list[1]))
+	} else {
+		y17d10KnotHash(list, lengths, 64)
+		denseHash := make([]int, len(list)/16)
+		for i := 0; i < len(list); i += 16 {
+			for j := 0; j < 16; j++ {
+				denseHash[i/16] ^= list[i+j]
+			}
+		}
+		sb.WriteString(y17d10ToHex(denseHash))
+	}
+	return sb.String()
 }
 
-func y17d10ReverseSlice(list []int, start int, stop int, length int) {
-	size := len(list)
-	dupe := make([]int, size)
-	copy(dupe, list)
-	for i := 0; i < length; i++ {
-		i1 := y17d10Modulo(start+i, size)
-		i2 := y17d10Modulo(stop-i, size)
-		list[i1] = dupe[i2]
+func y17d10CreateList(listLength int) (list []int) {
+	list = []int{}
+	for i := 0; i < listLength; i++ {
+		list = append(list, i)
 	}
+	return
 }
 
 func y17d10KnotHash(list []int, lengths []int, cycles int) {
@@ -36,20 +49,12 @@ func y17d10KnotHash(list []int, lengths []int, cycles int) {
 	}
 }
 
-func y17d10(input string, listLength, part int) (product int) {
-	lengths := y17d10ParseInput(input)
-	list := y17d10CreateList(listLength)
-	y17d10KnotHash(list, lengths, 1)
-	product = list[0] * list[1]
-	return
-}
-
-func y17d10CreateList(listLength int) (list []int) {
-	list = []int{}
-	for i := 0; i < listLength; i++ {
-		list = append(list, i)
+func y17d10Modulo(number, length int) int {
+	if number < 0 {
+		return y17d10Modulo(length+number, length)
+	} else {
+		return number % length
 	}
-	return
 }
 
 func y17d10ParseInput(input string) (lengths []int) {
@@ -57,4 +62,31 @@ func y17d10ParseInput(input string) (lengths []int) {
 		lengths = append(lengths, strToInt(n))
 	}
 	return
+}
+
+func y17d10ParseInputPart2(input string) (lengths []int) {
+	for _, c := range input {
+		lengths = append(lengths, int(c))
+	}
+	lengths = append(lengths, 17, 31, 73, 47, 23)
+	return
+}
+
+func y17d10ReverseSlice(list []int, start, stop, length int) {
+	size := len(list)
+	dupe := make([]int, size)
+	copy(dupe, list)
+	for i := 0; i < length; i++ {
+		i1 := y17d10Modulo(start+i, size)
+		i2 := y17d10Modulo(stop-i, size)
+		list[i1] = dupe[i2]
+	}
+}
+
+func y17d10ToHex(list []int) string {
+	sb := strings.Builder{}
+	for _, element := range list {
+		sb.WriteString(fmt.Sprintf("%02x", element))
+	}
+	return sb.String()
 }

--- a/go/adventofcode/y17d10_test.go
+++ b/go/adventofcode/y17d10_test.go
@@ -13,9 +13,13 @@ func Test_y17d10(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        args
-		wantProduct int
+		wantProduct string
 	}{
-		{"test p1", args{input: y17d10TestInput, listLength: 5, part: 1}, 12},
+		{"test p1", args{input: y17d10TestInput, listLength: 5, part: 1}, "12"},
+		{"test p2", args{input: "", listLength: 256, part: 2}, "a2582a3a0e66e6e86e3812dcb672a272"},
+		{"test p2", args{input: "AoC 2017", listLength: 256, part: 2}, "33efeb34ea91902bb2f59c9920caa6cd"},
+		{"test p2", args{input: "1,2,3", listLength: 256, part: 2}, "3efbe78a8d82f29979031a4aa0b16a9d"},
+		{"test p2", args{input: "1,2,4", listLength: 256, part: 2}, "63960835bcdc130f0b66d7ff4f6a5a8e"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Execution

```
> make run YEAR=2017 DAY=10
Year=2017 Day=10 Part 1: 6909 (195.375µs)
Year=2017 Day=10 Part 2: 9d5f4561367d379cfbf04f8c471c0095 (3.538167ms)
```

# Tests

```
> make test | grep y17d10.go | column -t
github.com/bandarji/aoc/adventofcode/y17d10.go:8:   y17d10                 100.0%
github.com/bandarji/aoc/adventofcode/y17d10.go:31:  y17d10CreateList       100.0%
github.com/bandarji/aoc/adventofcode/y17d10.go:39:  y17d10KnotHash         100.0%
github.com/bandarji/aoc/adventofcode/y17d10.go:52:  y17d10Modulo           100.0%
github.com/bandarji/aoc/adventofcode/y17d10.go:60:  y17d10ParseInput       100.0%
github.com/bandarji/aoc/adventofcode/y17d10.go:67:  y17d10ParseInputPart2  100.0%
github.com/bandarji/aoc/adventofcode/y17d10.go:75:  y17d10ReverseSlice     100.0%
github.com/bandarji/aoc/adventofcode/y17d10.go:86:  y17d10ToHex            100.0%
```